### PR TITLE
Plugin will apply setup if wasn't applied on existing files, added more options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## This repo is a *fork* of [soemre/commentless.nvim](https://github.com/soemre/commentless.nvim)
+
+This repo is a *fork* for some new options and compatibility with [Folke's LazyVim's](https://github.com/LazyVim/LazyVim) default options.
+
+If you're having issues with LazyVim compatibility you *might* find solution here.
+
+Please, checkout creator of this plugin repo: [soemre/commentless.nvim](https://github.com/soemre/commentless.nvim)
+
 # 🧘 commentless.nvim
 
 Hide comments, focus on the code flow, and reveal them if needed.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ vim.keymap.set("n", "<leader>/", function()
 end)
 ```
 
+or with [Folke's snacks](https://github.com/folke/snacks.nvim)
+
+```lua
+-- folke/snacks.nvim
+Snacks.toggle({
+  name = "Comments",
+  notify = false,
+  get = function()
+    return require("commentless").is_hidden()
+  end,
+  set = function()
+    require("commentless").toggle()
+  end,
+  wk_desc = {
+    enabled = "Reveal ",
+    disabled = "Hide ",
+  },
+}):map("<leader>/")
+```
+
 ## 🛠️ Configuration
 
 Check `:help commentless` for full documentation.
@@ -63,6 +83,11 @@ Check `:help commentless` for full documentation.
 ```lua
 {
     hide_following_blank_lines = true,
+    hide_current_comment = true,
+    enable_notifications = true,
+    using_folke_lazyvim_setup = false,
+    apply_to_new_buffer = false,
+    apply_on_buffer_change = false,
     foldtext = function(folded_count)
         return "(" .. folded_count .. " comments)"
     end,

--- a/doc/commentless.txt
+++ b/doc/commentless.txt
@@ -36,6 +36,22 @@ commentless.setup({opts})
             {hide_current_comment} `nil|boolean`
                 When set to true, it hides the comment your cursor is
                 currently on.
+            {enable_notifications} nil|boolean
+                Notify after hiding or revealing comments.
+            {using_folke_lazyvim_setup} nil|boolean
+                Set to true if you're using Folke's LazyVim setup.
+                LazyVim has default vim.opt.foldlevel set to 99,
+                which ignores this plugin's fold.
+            {apply_to_new_buffer} nil|boolean
+                Hide comments in newly opened buffers, plugin setup is called
+                with BufReadFile and BufNewFile autocmd values.
+                It doesn't reapply to already existing buffers.
+                Note with lazy.nvim plugin is not loaded until it's called.
+            {apply_on_buffer_change} nil|boolean
+                Reapply hide comments with buffer change, plugin setup is
+                called with BufEnter ayticnd value. It does work for already
+                exising buffers, but it's NOT optimized, setup it can be
+                called multiple times on single action.
             {foldtext} `nil|function`
                 The value it returns sets the text displayed for the
                 folded/hidden comment blocks.
@@ -45,7 +61,15 @@ commentless.setup({opts})
 {
     hide_following_blank_lines = true,
 
-		hide_current_comment = true,
+	  hide_current_comment = true,
+
+    enable_notifications = true,
+
+    using_folke_lazyvim_setup = false,
+
+    apply_to_new_buffer = false,
+
+    apply_on_buffer_change = false,
 
     foldtext = function(folded_count)
         return "(" .. folded_count .. " comments)"
@@ -77,13 +101,14 @@ commentless.is_hidden()
 COMMANDS                                                *commentless.commands*
 
                                                                 *:Commentless*
-Some API commands are available under `:Commentless <args>`.
+API commands are available under `:Commentless <args>`.
 If no argument is provided, it defaults to `toggle`.
 
 Available `<args>`: ~
 - `toggle`
 - `hide`
 - `reveal`
+- `is_hidden`
 
 
 vim:tw=80:ts=2:ft=help:norl:syntax=help:

--- a/lua/commentless/config.lua
+++ b/lua/commentless/config.lua
@@ -11,6 +11,10 @@ function M.defaults()
 	local defaults = {
 		hide_following_blank_lines = true,
 		hide_current_comment = true,
+		enable_notifications = true,
+		using_folke_lazyvim_setup = false,
+		apply_to_new_buffer = false,
+		apply_on_buffer_change = false,
 		foldtext = function(folded_count)
 			return "(" .. folded_count .. " comments)"
 		end,

--- a/lua/commentless/init.lua
+++ b/lua/commentless/init.lua
@@ -11,6 +11,7 @@ function M.setup(options)
 		["toggle"] = M.toggle,
 		["hide"] = M.hide,
 		["reveal"] = M.reveal,
+		["is_hidden"] = M.is_hidden_cmd,
 	}
 
 	vim.api.nvim_create_user_command("Commentless", function(cmd)
@@ -30,6 +31,37 @@ function M.setup(options)
 			return keys
 		end,
 	})
+
+	-- Apply hide comments to either new or switched buffers
+	local autocmdHooks = {}
+
+	if config.options.apply_to_new_buffer then
+		table.insert(autocmdHooks, "BufReadPost")
+		table.insert(autocmdHooks, "BufNewFile")
+	end
+
+	if config.options.apply_on_buffer_change then
+		-- overwriting since it'll be called on new Buffers as well.
+		autocmdHooks = { "BufEnter" }
+	end
+
+	local onAutocmd = function()
+		vim.schedule(function()
+			if internal.is_hidden() then
+				internal.hide()
+			else
+				internal.reveal()
+			end
+		end)
+	end
+
+	if next(autocmdHooks) ~= nil then
+		vim.api.nvim_create_autocmd(autocmdHooks, {
+			callback = function()
+				onAutocmd()
+			end,
+		})
+	end
 end
 
 function M.toggle()
@@ -46,6 +78,10 @@ end
 
 function M.is_hidden()
 	return internal.is_hidden()
+end
+
+function M.is_hidden_cmd()
+	vim.notify("Comments are " .. (M.is_hidden() and "hidden" or "revealed"))
 end
 
 return M

--- a/lua/commentless/internal.lua
+++ b/lua/commentless/internal.lua
@@ -21,19 +21,39 @@ function M.setup()
 	opt.foldtext = req_int .. ".foldtext()"
 end
 
+-- For already opened buffers the setup wasn't applied.
+function M.check_setup()
+	if vim.opt.foldexpr ~= "v:lua.require'commentless.internal'.foldexpr()" then
+		M.setup()
+	end
+end
+
+-- Mainly so user sees the Commenltess is responsive
+function M.notify_user()
+	if config.options.enable_notifications then
+		vim.notify("Comments are " .. (M._hidden and "hidden" or "revealed"))
+	end
+end
+
 function M.toggle()
+	M.check_setup()
 	M._hidden = not M._hidden
 	utils.reload()
+	M.notify_user()
 end
 
 function M.hide()
+	M.check_setup()
 	M._hidden = true
 	utils.reload()
+	M.notify_user()
 end
 
 function M.reveal()
+	M.check_setup()
 	M._hidden = false
 	utils.reload()
+	M.notify_user()
 end
 
 function M.is_hidden()

--- a/lua/commentless/utils.lua
+++ b/lua/commentless/utils.lua
@@ -19,8 +19,14 @@ end
 function M.reload()
 	if config.options.hide_current_comment then
 		vim.cmd("normal! zX") -- Update folds
+		if config.options.using_folke_lazyvim_setup then
+			vim.cmd("normal! zM") -- Hide comments for LazyVim
+		end
 	else
 		vim.cmd("normal! zx") -- Update folds
+		if config.options.using_folke_lazyvim_setup then
+			vim.cmd("normal! zR") -- Reveal comments for LazyVim
+		end
 	end
 end
 


### PR DESCRIPTION
Hi, first of all, I'm glad you've made this plugin, there aren't many plugins for folding comments.

I've had some issues with LazyVim due to LazyVim's setup default options, I've managed to make it work with default options.

I have had issue with hiding comments with more buffers, applying setup with function calls fixed this for me, I'm not sure if it was a *me* problem or LazyVim's defaults. 

While working on plugin I've added some options, new options:
* enable_notifications &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;> Notify user of language change. (I wasn't sure if plugin does it's job due to LazyVim setup)
* using_folke_lazyvim_setup > Compatibility with Folke's LazyVim setup.
* apply_to_new_buffer &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;> Apply setup to new buffers, and hide/reveal.
* apply_on_buffer_change &nbsp;&nbsp;&nbsp;> Apply hide/reveal on every buffer change. I must admit, this might not be the best way for applying setup for already existing buffers, but it does the trick.